### PR TITLE
Search service parameters unification

### DIFF
--- a/scraper/src/index.js
+++ b/scraper/src/index.js
@@ -49,22 +49,24 @@ const getWebsiteContent = (url, taskId, publisher) => {
                     .text()
                     .match(/\(([^)]+)\)/)[1];
                 const metadata = {
-                    taskId,
-                    offerId,
-                    title,
-                    subtitle,
-                    price: parseInt(price),
-                    currency,
-                    url,
-                    imgUrl: image,
-                    params: {
-                        year: parseFloat(year),
-                        mileage: mileage,
-                        engine_capacity,
-                        fuel_type,
-                        town,
-                            region
-                        },
+                    result: {
+                        taskId,
+                        offerId,
+                        title,
+                        subtitle,
+                        price: parseInt(price),
+                        currency,
+                        url,
+                        imgUrl: image,
+                        params: {
+                            year: parseFloat(year),
+                            mileage: mileage,
+                            engine_capacity,
+                            fuel_type,
+                            town,
+                                region
+                            },
+                    },
                     last: false
                 };
                 parsedResults.push(metadata);

--- a/search-service/db/arm/Dockerfile
+++ b/search-service/db/arm/Dockerfile
@@ -5,9 +5,15 @@ EXPOSE 3306
 ENV MYSQL_ROOT_PASSWORD ptsecret
 ENV MYSQL_DATABASE searches
 
+RUN apt update
+RUN apt install dos2unix
+
 COPY ./create.sql /init.sql
 COPY ./run-db.sh /run-db.sh
-RUN ["chmod", "+x", "/run-db.sh" ]
+
+RUN dos2unix /init.sql -o /init.sql
+RUN dos2unix /run-db.sh -o /run-db.sh
+RUN chmod +x /run-db.sh
 
 ENTRYPOINT [ "/run-db.sh" ]
 CMD ["mysqld"]

--- a/search-service/db/create.sql
+++ b/search-service/db/create.sql
@@ -30,12 +30,13 @@ CREATE TABLE task (
 CREATE TABLE result (
     id bigint unsigned unique KEY AUTO_INCREMENT,
     task_id varchar(36) NOT NULL,
+    offer_id varchar(64) NULl default null,
     title varchar(256) NOT NULL,
-    subtitle text NULL,
+    subtitle text NULL default null,
     price decimal(12, 2) NOT NULL,
     currency varchar(5) NOT NULL default 'PLN',
-    url text NULL,
-    imgUrl text NULL,
+    url text NOT NULL,
+    imgUrl text NULL default null,
 
     PRIMARY KEY (id),
     FOREIGN KEY (task_id) REFERENCES task(id)

--- a/search-service/db/x86/Dockerfile
+++ b/search-service/db/x86/Dockerfile
@@ -5,9 +5,15 @@ EXPOSE 3306
 ENV MYSQL_ROOT_PASSWORD ptsecret
 ENV MYSQL_DATABASE searches
 
+RUN apt update
+RUN apt install dos2unix
+
 COPY ./create.sql /init.sql
 COPY ./run-db.sh /run-db.sh
-RUN ["chmod", "+x", "/run-db.sh" ]
+
+RUN dos2unix /init.sql -o /init.sql
+RUN dos2unix /run-db.sh -o /run-db.sh
+RUN chmod +x /run-db.sh
 
 ENTRYPOINT [ "/run-db.sh" ]
 CMD ["mysqld"]

--- a/search-service/sandbox/scraper-mock.py
+++ b/search-service/sandbox/scraper-mock.py
@@ -21,6 +21,7 @@ def mock():
 def publish_result(id, n, last=False):
     msg = {
         'taskId': id,
+        'offerId': int(random() * 1000000),
         'title': f'good car {n}',
         'subtitle': f'buy it',
         'price': int(random() * 500_000),

--- a/search-service/src/main/resources/application.conf
+++ b/search-service/src/main/resources/application.conf
@@ -15,6 +15,19 @@ service {
     delay: 20
     interval: 10800
   }
+  result {
+    allowedParams: [
+      "brand",
+      "model",
+      "enginge",
+      "year_from",
+      "year_to",
+      "price_from",
+      "price_to",
+      "mileage_from",
+      "mileage_to"
+    ]
+  }
   api {
     host: "0.0.0.0"
     port: 30001

--- a/search-service/src/main/resources/application.conf
+++ b/search-service/src/main/resources/application.conf
@@ -14,8 +14,6 @@ service {
   search {
     delay: 20
     interval: 10800
-  }
-  result {
     allowedParams: [
       "brand",
       "model",

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/domain/repository/ResultsRepository.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/domain/repository/ResultsRepository.scala
@@ -46,7 +46,7 @@ private class ResultsRepository(
 
   private def addNewResult(result: Result): Behavior[ResultsRepoMsg] = {
     val action = Future {
-      (None, result.taskId, result.title, result.subtitle, result.price, result.currency, result.url, result.imgUrl)
+      (None, result.taskId, result.offerId, result.title, result.subtitle, result.price, result.currency, result.url, result.imgUrl)
     }.map { (_, TableQuery[Results]) }
       .flatMap { case (row, table) =>
         session.db.run((table returning table.map(_.id)) += row)
@@ -81,7 +81,7 @@ private class ResultsRepository(
         .map { _.sortWith(_._1 > _._2) }
         .map { ListMap.newBuilder.addAll(_).result }
         .map {
-          Result(row.id, row.taskId, row.title, row.subtitle, row.price, row.currency, row.url, row.imgUrl, _)
+          Result(row.id, row.taskId, row.offerId, row.title, row.subtitle, row.price, row.currency, row.url, row.imgUrl, _)
         }
     }
       .runWith(Sink.seq)

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/domain/repository/SearchRepository.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/domain/repository/SearchRepository.scala
@@ -29,7 +29,7 @@ object SearchRepository {
 
   case class EndSearchRepo() extends SearchRepoMsg
 
-  private val allowedParams = ConfigFactory.load().getStringList("service.result.allowedParams")
+  private val allowedParams = ConfigFactory.load().getStringList("service.search.allowedParams")
 
   case class InvalidParamException(param: String) extends Exception(
     s"Invalid param: $param. Allowed params are: $allowedParams"

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/model/Result.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/model/Result.scala
@@ -3,11 +3,12 @@ package eu.jrie.put.cs.pt.scrapper.model
 case class Result (
                     id: Option[Long],
                     taskId: String,
+                    offerId: Option[String],
                     title: String,
                     subtitle: Option[String],
                     price: Double,
                     currency: String,
-                    url: Option[String],
+                    url: String,
                     imgUrl: Option[String],
                     params: Map[String, String]
                   )

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/model/db/Tables.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/model/db/Tables.scala
@@ -60,29 +60,31 @@ object Tables {
     case class ResultRow (
                            id: Option[Long],
                            taskId: String,
+                           offerId: Option[String],
                            title: String,
                            subtitle: Option[String],
                            price: Double,
                            currency: String,
-                           url: Option[String],
+                           url: String,
                            imgUrl: Option[String]
                          )
 
     implicit val getResultRow: AnyRef with GetResult[ResultRow] = GetResult(r => {
-      ResultRow(r.nextLongOption, r.nextString, r.nextString, r.nextStringOption, r.nextDouble, r.nextString, r.nextStringOption, r.nextStringOption)
+      ResultRow(r.nextLongOption, r.nextString, r.nextStringOption, r.nextString, r.nextStringOption, r.nextDouble, r.nextString, r.nextString, r.nextStringOption)
     })
 
-    class Results (tag: Tag) extends Table[(Option[Long], String, String, Option[String], Double, String, Option[String], Option[String])](tag, "result") {
+    class Results (tag: Tag) extends Table[(Option[Long], String, Option[String], String, Option[String], Double, String, String, Option[String])](tag, "result") {
       def id = column[Option[Long]]("id", O.PrimaryKey, O.AutoInc)
       def taskId = column[String]("task_id")
+      def offerId = column[Option[String]]("offer_id")
       def title = column[String]("title")
       def subtitle = column[Option[String]]("subtitle")
       def price = column[Double]("price")
       def currency = column[String]("currency")
-      def url = column[Option[String]]("url")
+      def url = column[String]("url")
       def imgUrl = column[Option[String]]("imgUrl")
 
-      def * = (id, taskId, title, subtitle, price, currency, url, imgUrl)
+      def * = (id, taskId, offerId, title, subtitle, price, currency, url, imgUrl)
     }
   }
 

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Message.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Message.scala
@@ -1,19 +1,10 @@
 package eu.jrie.put.cs.pt.scrapper.redis
 
+import eu.jrie.put.cs.pt.scrapper.model.Result
+
 object Message {
   trait RedisMessage
 
   case class TaskMessage(taskId: String, params: Map[String, String]) extends RedisMessage
-  case class ResultMessage(
-                            taskId: String,
-                            offerId: Option[String],
-                            title: String,
-                            subtitle: Option[String],
-                            url: String,
-                            imgUrl: Option[String],
-                            price: Double,
-                            currency: String,
-                            params: Map[String, String],
-                            last: Boolean
-                          ) extends RedisMessage
+  case class ResultMessage(result: Result, last: Boolean) extends RedisMessage
 }

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Message.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Message.scala
@@ -6,9 +6,10 @@ object Message {
   case class TaskMessage(taskId: String, params: Map[String, String]) extends RedisMessage
   case class ResultMessage(
                             taskId: String,
+                            offerId: Option[String],
                             title: String,
                             subtitle: Option[String],
-                            url: Option[String],
+                            url: String,
                             imgUrl: Option[String],
                             price: Double,
                             currency: String,

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Subscriber.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Subscriber.scala
@@ -4,7 +4,7 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.alpakka.slick.scaladsl.SlickSession
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.redis.{M, PubSubMessage, RedisClient}
 import eu.jrie.put.cs.pt.scrapper.domain.repository.{ResultsRepository, TasksRepository}
@@ -30,7 +30,7 @@ object Subscriber {
         case M(channel, rawMsg) =>
           val msg: ResultMessage = asMsg(rawMsg)
           context.log.debug ("received {} for task {} from {}", msg.title, msg.taskId, channel)
-          val result = Result(None, msg.taskId, msg.title, msg.subtitle, msg.price, msg.currency, msg.url, msg.imgUrl, msg.params)
+          val result = Result(None, msg.taskId, msg.offerId, msg.title, msg.subtitle, msg.price, msg.currency, msg.url, msg.imgUrl, msg.params)
           resultsWriter ! WriteResult(result, msg.last)
         case _ =>
       }

--- a/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Subscriber.scala
+++ b/search-service/src/main/scala/eu/jrie/put/cs/pt/scrapper/redis/Subscriber.scala
@@ -29,9 +29,8 @@ object Subscriber {
       m match {
         case M(channel, rawMsg) =>
           val msg: ResultMessage = asMsg(rawMsg)
-          context.log.debug ("received {} for task {} from {}", msg.title, msg.taskId, channel)
-          val result = Result(None, msg.taskId, msg.offerId, msg.title, msg.subtitle, msg.price, msg.currency, msg.url, msg.imgUrl, msg.params)
-          resultsWriter ! WriteResult(result, msg.last)
+          context.log.debug ("received {} for task {} from {}", msg.result.title, msg.result.taskId, channel)
+          resultsWriter ! WriteResult(msg.result, msg.last)
         case _ =>
       }
     }


### PR DESCRIPTION
* dodawane wyszukiwania mogą mieć tylko parametry zdefiniowane w search-service/src/main/resources/application.conf
* w przypadku `POST` z nieobsługiwanym parametrem zostanie zwrócone `422`
* `result` posiada pole `offerId`
* dodatkowo poprawiłem końce linii w Dockerfile dla bazy 
* dla porządku kodu i DRY zmieniłem model `ResultMessage`, poprawiłem go też w scraperze @SuddenlyPineapple 